### PR TITLE
Expose info fields

### DIFF
--- a/core/src/main/scala/com/acervera/osm4scala/DenseNodesIterator.scala
+++ b/core/src/main/scala/com/acervera/osm4scala/DenseNodesIterator.scala
@@ -26,6 +26,7 @@
 package com.acervera.osm4scala
 
 import com.acervera.osm4scala.model.NodeEntity
+import com.acervera.osm4scala.utilities.DecompressUtils
 import com.acervera.osm4scala.utilities.DecompressUtils.{decompressChangeset, decompressCoord, decompressTimestamp, decompressUid, decompressUserSid, iteratorCheck}
 import org.openstreetmap.osmosis.osmbinary.osmformat.{DenseInfo, DenseNodes, StringTable}
 
@@ -37,6 +38,7 @@ import org.openstreetmap.osmosis.osmbinary.osmformat.{DenseInfo, DenseNodes, Str
   * @param latOffset
   * @param lonOffset
   * @param granularity
+  * @param dateGranularity
   */
 case class DenseNodesIterator(osmosisStringTable: StringTable,
                          osmosisDenseNode: DenseNodes,
@@ -46,73 +48,89 @@ case class DenseNodesIterator(osmosisStringTable: StringTable,
                          dateGranularity: Option[Int] = None)
     extends Iterator[NodeEntity] {
 
-  private val idIterator: Iterator[Long] = osmosisDenseNode.id.toIterator
-  private val lonIterator: Iterator[Long]  = osmosisDenseNode.lon.toIterator
-  private val latIterator: Iterator[Long]  = osmosisDenseNode.lat.toIterator
-  private val tagsIterator: Iterator[Int] = osmosisDenseNode.keysVals.toIterator
+  private val idIterator: Iterator[Long] = osmosisDenseNode.id.iterator
+  private val lonIterator: Iterator[Long]  = osmosisDenseNode.lon.iterator
+  private val latIterator: Iterator[Long]  = osmosisDenseNode.lat.iterator
+  private val tagsIterator: Iterator[Int] = osmosisDenseNode.keysVals.iterator
   private val optionDenseInfo: Option[DenseInfo] = osmosisDenseNode.denseinfo
-  private val versionIterator: Iterator[Int] = if(optionDenseInfo.isDefined) optionDenseInfo.get.version.toIterator else Iterator.empty
-  private val timestampIterator: Iterator[Long] = if(optionDenseInfo.isDefined) optionDenseInfo.get.timestamp.toIterator else Iterator.empty
-  private val changesetIterator: Iterator[Long]  = if(optionDenseInfo.isDefined) optionDenseInfo.get.changeset.toIterator else Iterator.empty
-  private val uidIterator: Iterator[Int]  = if(optionDenseInfo.isDefined) optionDenseInfo.get.uid.toIterator else Iterator.empty
-  private val userSidIterator: Iterator[Int]  = if(optionDenseInfo.isDefined) optionDenseInfo.get.userSid.toIterator else Iterator.empty
-  private val visibleIterator: Iterator[Boolean]  = if(optionDenseInfo.isDefined) optionDenseInfo.get.visible.toIterator else Iterator.empty
+  private val versionIterator: Iterator[Int] = if(optionDenseInfo.isDefined) optionDenseInfo.get.version.iterator else Iterator.empty
+  private val timestampIterator: Iterator[Long] = if(optionDenseInfo.isDefined) optionDenseInfo.get.timestamp.iterator else Iterator.empty
+  private val changesetIterator: Iterator[Long]  = if(optionDenseInfo.isDefined) optionDenseInfo.get.changeset.iterator else Iterator.empty
+  private val uidIterator: Iterator[Int]  = if(optionDenseInfo.isDefined) optionDenseInfo.get.uid.iterator else Iterator.empty
+  private val userSidIterator: Iterator[Int]  = if(optionDenseInfo.isDefined) optionDenseInfo.get.userSid.iterator else Iterator.empty
+  private val visibleIterator: Iterator[Boolean]  = if(optionDenseInfo.isDefined) optionDenseInfo.get.visible.iterator else Iterator.empty
 
   private val _latOffSet: Long = latOffset.getOrElse[Long](DenseNodesIterator.DEFAULT_LAT_OFFSET)
   private val _lonOffSet: Long = lonOffset.getOrElse[Long](DenseNodesIterator.DEFAULT_LON_OFFSET)
   private val _granularity: Int = granularity.getOrElse[Int](DenseNodesIterator.DEFAULT_GRANULARITY)
   private val _dateGranularity: Int = dateGranularity.getOrElse[Int](DenseNodesIterator.DEFAULT_DATE_GRANULARITY)
 
-  private var lastNode: NodeEntity = NodeEntity(
+  private var deltaDecodeCursor: DeltaDecodeCursor = DeltaDecodeCursor(
     id = 0,
     latitude = 0,
     longitude = 0,
-    tags = Map(),
-    version = None,
-    timestamp = None,
-    changeset = None,
     uid = None,
-    user_sid = None,
-    visible = None
+    userSid = None,
+    timestamp = None,
+    changeset = None
   )
 
   override def hasNext: Boolean = idIterator.hasNext
 
   override def next(): NodeEntity = {
 
-    val id = idIterator.next() + lastNode.id
+    val id = idIterator.next() + deltaDecodeCursor.id
     val latitude =
-      decompressCoord(_latOffSet, latIterator.next(), _granularity, lastNode.latitude)
+      decompressCoord(_latOffSet, latIterator.next(), _granularity, deltaDecodeCursor.latitude)
     val longitude =
-      decompressCoord(_lonOffSet, lonIterator.next(), _granularity, lastNode.longitude)
+      decompressCoord(_lonOffSet, lonIterator.next(), _granularity, deltaDecodeCursor.longitude)
     val tags = tagsIterator
       .takeWhile(_ != 0L)
       .grouped(2)
       .map { tag =>
-        osmosisStringTable.s(tag.head).toString("UTF-8") -> osmosisStringTable
-          .s(tag.last)
-          .toString("UTF-8")
+        osmosisStringTable.s(tag.head).toString(DecompressUtils.STRING_ENCODER) ->
+          osmosisStringTable.s(tag.last).toString(DecompressUtils.STRING_ENCODER)
       }
       .toMap
 
+    val version: Option[Int] = iteratorCheck[Int](versionIterator)
+    val timestamp: Option[Long] = decompressTimestamp(iteratorCheck[Long](timestampIterator), _dateGranularity, deltaDecodeCursor.timestamp)
+    val uid: Option[Int] = decompressUid(iteratorCheck[Int](uidIterator), deltaDecodeCursor.uid)
+    val userSid: Option[Int] = decompressUserSid(iteratorCheck[Int](userSidIterator), deltaDecodeCursor.userSid)
+    val user: Option[String] = userSid.map(id => osmosisStringTable.s(id).toString(DecompressUtils.STRING_ENCODER))
+    val changeset: Option[Long] = decompressChangeset(iteratorCheck[Long](changesetIterator), deltaDecodeCursor.changeset)
+    val visible: Option[Boolean] = iteratorCheck[Boolean](visibleIterator)
+
+    //Update the cursor here
+    deltaDecodeCursor = DeltaDecodeCursor(
+      id = id,
+      latitude = latitude,
+      longitude = longitude,
+      uid = uid,
+      userSid = userSid,
+      timestamp = timestamp,
+      changeset = changeset
+    )
+
     // Create node
-    lastNode = NodeEntity(
+    NodeEntity(
       id = id,
       latitude = latitude,
       longitude = longitude,
       tags = tags,
-      version = iteratorCheck[Int](versionIterator),
-      timestamp = decompressTimestamp(iteratorCheck[Long](timestampIterator), _dateGranularity, lastNode.timestamp),
-      changeset = decompressChangeset(iteratorCheck[Long](changesetIterator), lastNode.changeset),
-      uid = decompressUid(iteratorCheck[Int](uidIterator), lastNode.uid),
-      user_sid = decompressUserSid(iteratorCheck[Int](userSidIterator), lastNode.user_sid),
-      visible = iteratorCheck[Boolean](visibleIterator)
+      version = version,
+      timestamp = timestamp,
+      changeset = changeset,
+      uid = uid,
+      user = user,
+      visible = visible
     )
-
-    lastNode
   }
 
 }
+
+case class DeltaDecodeCursor(id: Long, latitude: Double, longitude: Double, uid: Option[Int], userSid: Option[Int], timestamp: Option[Long], changeset: Option[Long])
+
 
 object DenseNodesIterator {
   private val DEFAULT_LAT_OFFSET = 0

--- a/core/src/main/scala/com/acervera/osm4scala/FromPbfFileEntitiesIterator.scala
+++ b/core/src/main/scala/com/acervera/osm4scala/FromPbfFileEntitiesIterator.scala
@@ -60,7 +60,7 @@ class FromPbfFileEntitiesIterator(pbfInputStream: InputStreamSentinel) extends E
   /**
     * Read the next osm pbf block
     */
-  private def readNextBlock() =
+  private def readNextBlock(): Option[EntityIterator] =
     if (blobIterator.hasNext) {
       Some(EntityIterator.fromBlob(blobIterator.next()._2))
     } else {

--- a/core/src/main/scala/com/acervera/osm4scala/model/NodeEntity.scala
+++ b/core/src/main/scala/com/acervera/osm4scala/model/NodeEntity.scala
@@ -36,7 +36,7 @@ case class NodeEntity(id: Long,
                       timestamp: Option[Long],
                       changeset: Option[Long],
                       uid: Option[Int],
-                      user_sid: Option[Int],
+                      user: Option[String],
                       visible: Option[Boolean]) extends OSMEntity {
   override val osmModel: OSMTypes.Value = OSMTypes.Node
 
@@ -56,7 +56,7 @@ case class NodeEntity(id: Long,
       s"timestamp: ${timestamp.getOrElse("None")}, " +
       s"changeset: ${changeset.getOrElse("None")}, " +
       s"uid: ${uid.getOrElse("None")}, " +
-      s"user_sid: ${user_sid.getOrElse("None")}, " +
-      s"visible: ${visible.getOrElse("True")}\n"
+      s"user: ${user.getOrElse("None")}, " +
+      s"visible: ${visible.getOrElse("None")}\n"
   }
 }

--- a/core/src/main/scala/com/acervera/osm4scala/model/NodeEntity.scala
+++ b/core/src/main/scala/com/acervera/osm4scala/model/NodeEntity.scala
@@ -28,6 +28,35 @@ package com.acervera.osm4scala.model
 /**
   * Entity that represent a OSM node as https://wiki.openstreetmap.org/wiki/Elements#Node and https://wiki.openstreetmap.org/wiki/Node describe
   */
-case class NodeEntity(id: Long, latitude: Double, longitude: Double, tags: Map[String, String]) extends OSMEntity {
+case class NodeEntity(id: Long,
+                      latitude: Double,
+                      longitude: Double,
+                      tags: Map[String, String],
+                      version: Option[Int],
+                      timestamp: Option[Long],
+                      changeset: Option[Long],
+                      uid: Option[Int],
+                      user_sid: Option[Int],
+                      visible: Option[Boolean]) extends OSMEntity {
   override val osmModel: OSMTypes.Value = OSMTypes.Node
+
+  def apply(id: Long,
+            latitude: Double,
+            longitude: Double,
+            tags: Map[String, String]): NodeEntity = {
+    NodeEntity(id, latitude, longitude, tags,
+      None, None, None, None, None, None)
+  }
+
+  override def toString: String = {
+    s"Node id: ${id}, " +
+      s"coordinate: (${latitude}, ${latitude}), " +
+      s"tags: ${tags.toList}, " +
+      s"version: ${version.getOrElse("None")}," +
+      s"timestamp: ${timestamp.getOrElse("None")}, " +
+      s"changeset: ${changeset.getOrElse("None")}, " +
+      s"uid: ${uid.getOrElse("None")}, " +
+      s"user_sid: ${user_sid.getOrElse("None")}, " +
+      s"visible: ${visible.getOrElse("True")}\n"
+  }
 }

--- a/core/src/main/scala/com/acervera/osm4scala/model/OSMEntity.scala
+++ b/core/src/main/scala/com/acervera/osm4scala/model/OSMEntity.scala
@@ -30,10 +30,16 @@ object OSMTypes extends Enumeration {
   val Way, Node, Relation = Value
 }
 
-trait OSMEntity {
+trait OSMEntity extends Product with Serializable {
 
   val osmModel: OSMTypes.Value
   val id: Long
   val tags: Map[String, String]
+  val version: Option[Int]
+  val timestamp: Option[Long]
+  val changeset: Option[Long]
+  val uid: Option[Int]
+  val user_sid: Option[Int]
+  val visible: Option[Boolean]
 
 }

--- a/core/src/main/scala/com/acervera/osm4scala/model/OSMEntity.scala
+++ b/core/src/main/scala/com/acervera/osm4scala/model/OSMEntity.scala
@@ -39,7 +39,6 @@ trait OSMEntity extends Product with Serializable {
   val timestamp: Option[Long]
   val changeset: Option[Long]
   val uid: Option[Int]
-  val user_sid: Option[Int]
+  val user: Option[String]
   val visible: Option[Boolean]
-
 }

--- a/core/src/main/scala/com/acervera/osm4scala/model/RelationEntity.scala
+++ b/core/src/main/scala/com/acervera/osm4scala/model/RelationEntity.scala
@@ -25,35 +25,91 @@
 
 package com.acervera.osm4scala.model
 
-import org.openstreetmap.osmosis.osmbinary.osmformat.{Relation, StringTable}
+import org.openstreetmap.osmosis.osmbinary.osmformat.{Info, Relation, StringTable}
 
 /**
   * Entity that represent a OSM relation as https://wiki.openstreetmap.org/wiki/Elements#Relation and https://wiki.openstreetmap.org/wiki/Relation describe
   */
-case class RelationEntity(id: Long, relations: Seq[RelationMemberEntity], tags: Map[String, String]) extends OSMEntity {
+case class RelationEntity(id: Long,
+                          relations: Seq[RelationMemberEntity],
+                          tags: Map[String, String],
+                          version: Option[Int],
+                          timestamp: Option[Long],
+                          changeset: Option[Long],
+                          uid: Option[Int],
+                          user_sid: Option[Int],
+                          visible: Option[Boolean]) extends OSMEntity {
 
   override val osmModel: OSMTypes.Value = OSMTypes.Relation
+
+  def apply(id: Long,
+            relations: Seq[RelationMemberEntity],
+            tags: Map[String, String]): RelationEntity = {
+    RelationEntity(id, relations, tags,
+      None, None, None, None, None, None)
+  }
+
+  override def toString: String = {
+    s"Relation id: ${id}, " +
+      s"relations: ${relations}, " +
+      s"tags: ${tags.toList}, " +
+      s"version: ${version.getOrElse("None")}," +
+      s"timestamp: ${timestamp.getOrElse("None")}, " +
+      s"changeset: ${changeset.getOrElse("None")}, " +
+      s"uid: ${uid.getOrElse("None")}, " +
+      s"user_sid: ${user_sid.getOrElse("None")}, " +
+      s"visible: ${visible.getOrElse("True")}\n"
+  }
 
 }
 
 object RelationEntity {
 
-  def apply(osmosisStringTable: StringTable, osmosisRelation: Relation): RelationEntity = {
+  val DEFAULT_DATE_GRANULARITY: Int = 1000
+
+  def apply(osmosisRelation: Relation, osmosisStringTable: StringTable): RelationEntity = {
+    apply(osmosisRelation, osmosisStringTable, Option[Int](DEFAULT_DATE_GRANULARITY))
+  }
+
+  def apply(osmosisRelation: Relation,
+            osmosisStringTable: StringTable,
+            dateGranularity: Option[Int]): RelationEntity = {
+
+    val _dateGranularity: Int = dateGranularity.getOrElse(DEFAULT_DATE_GRANULARITY)
 
     // Calculate tags using the StringTable.
-    val tags = (osmosisRelation.keys, osmosisRelation.vals).zipped.map { (k, v) =>
+    val tags: Map[String, String] = (osmosisRelation.keys, osmosisRelation.vals).zipped.map { (k, v) =>
       osmosisStringTable.s(k).toString("UTF-8") -> osmosisStringTable.s(v).toString("UTF-8")
     }.toMap
 
     // Decode members references in stored in delta compression.
-    val members = osmosisRelation.memids.scanLeft(0L) { _ + _ }.drop(1)
+    val members: Seq[Long] = osmosisRelation.memids.scanLeft(0L) { _ + _ }.drop(1)
+
+    val optionalInfo: Option[Info] = osmosisRelation.info
 
     // Calculate relations
-    val relations = (members, osmosisRelation.types, osmosisRelation.rolesSid).zipped.map { (m, t, r) =>
+    val relations: Seq[RelationMemberEntity] = (members, osmosisRelation.types, osmosisRelation.rolesSid).zipped.map { (m, t, r) =>
       RelationMemberEntity(m, RelationMemberEntityTypes(t.value), osmosisStringTable.s(r).toString("UTF-8"))
     }
 
-    new RelationEntity(osmosisRelation.id, relations, tags)
+    val version: Option[Int] = optionalInfo.filter(_.version.isDefined).map(_.version.get)
+    val timestamp: Option[Long] = optionalInfo.filter(_.timestamp.isDefined).map(_.version.get * _dateGranularity)
+    val changeset: Option[Long] = optionalInfo.filter(_.changeset.isDefined).map(_.changeset.get)
+    val uid: Option[Int] = optionalInfo.filter(_.uid.isDefined).map(_.uid.get)
+    val user_sid: Option[Int] = optionalInfo.filter(_.userSid.isDefined).map(_.userSid.get)
+    val visible: Option[Boolean] = optionalInfo.filter(_.visible.isDefined).map(_.visible.get)
+
+    RelationEntity(
+      id = osmosisRelation.id,
+      relations = relations,
+      tags = tags,
+      version = version,
+      timestamp = timestamp,
+      changeset = changeset,
+      uid = uid,
+      user_sid = user_sid,
+      visible = visible
+    )
   }
 
 }

--- a/core/src/main/scala/com/acervera/osm4scala/model/WayEntity.scala
+++ b/core/src/main/scala/com/acervera/osm4scala/model/WayEntity.scala
@@ -25,14 +25,41 @@
 
 package com.acervera.osm4scala.model
 
-import org.openstreetmap.osmosis.osmbinary.osmformat.{StringTable, Way}
+import org.openstreetmap.osmosis.osmbinary.osmformat.{Info, StringTable, Way}
 
 /**
   * Entity that represent a OSM way as https://wiki.openstreetmap.org/wiki/Elements#Way and https://wiki.openstreetmap.org/wiki/Way describe
   */
-case class WayEntity(id: Long, nodes: Seq[Long], tags: Map[String, String]) extends OSMEntity {
+case class WayEntity(id: Long,
+                     nodes: Seq[Long],
+                     tags: Map[String, String],
+                     version: Option[Int],
+                     timestamp: Option[Long],
+                     changeset: Option[Long],
+                     uid: Option[Int],
+                     user_sid: Option[Int],
+                     visible: Option[Boolean]) extends OSMEntity {
 
   override val osmModel: OSMTypes.Value = OSMTypes.Way
+
+  def apply(id: Long,
+            nodes: Seq[Long],
+            tags: Map[String, String]): WayEntity = {
+    WayEntity(id, nodes, tags,
+      None, None, None, None, None, None)
+  }
+
+  override def toString: String = {
+    s"Way id: ${id}, " +
+      s"nodes: ${nodes}, " +
+      s"tags: ${tags.toList}, " +
+      s"version: ${version.getOrElse("None")}," +
+      s"timestamp: ${timestamp.getOrElse("None")}, " +
+      s"changeset: ${changeset.getOrElse("None")}, " +
+      s"uid: ${uid.getOrElse("None")}, " +
+      s"user_sid: ${user_sid.getOrElse("None")}, " +
+      s"visible: ${visible.getOrElse("True")}\n"
+  }
 
   object WayEntityTypes extends Enumeration { // TODO: How to know the type ?????
     val Open, Close, Area, CombinedClosedPolylineArea = Value
@@ -42,17 +69,46 @@ case class WayEntity(id: Long, nodes: Seq[Long], tags: Map[String, String]) exte
 
 object WayEntity {
 
-  def apply(osmosisStringTable: StringTable, osmosisWay: Way): WayEntity = {
+  val DEFAULT_DATE_GRANULARITY: Int = 1000
+
+  def apply(osmosisWay: Way, osmosisStringTable: StringTable): WayEntity = {
+    apply(osmosisWay, osmosisStringTable, Option[Int](DEFAULT_DATE_GRANULARITY))
+  }
+
+  def apply(osmosisWay: Way,
+            osmosisStringTable: StringTable,
+            dateGranularity: Option[Int]): WayEntity = {
+
+    val _dateGranularity: Int = dateGranularity.getOrElse(DEFAULT_DATE_GRANULARITY)
 
     // Calculate nodes references in stored in delta compression.
-    val nodes = osmosisWay.refs.scanLeft(0L) { _ + _ }.drop(1)
+    // Similar to calculate cumulative sum here, drop the first 0L
+    val nodes: Seq[Long] = osmosisWay.refs.scanLeft(0L) { _ + _ }.drop(1)
+    val optionalInfo: Option[Info] = osmosisWay.info
 
     // Calculate tags using the StringTable.
     val tags = (osmosisWay.keys, osmosisWay.vals).zipped.map { (k, v) =>
       osmosisStringTable.s(k).toString("UTF-8") -> osmosisStringTable.s(v).toString("UTF-8")
     }.toMap
 
-    new WayEntity(osmosisWay.id, nodes, tags)
+    val version: Option[Int] = optionalInfo.filter(_.version.isDefined).map(_.version.get)
+    val timestamp: Option[Long] = optionalInfo.filter(_.timestamp.isDefined).map(_.version.get * _dateGranularity)
+    val changeset: Option[Long] = optionalInfo.filter(_.changeset.isDefined).map(_.changeset.get)
+    val uid: Option[Int] = optionalInfo.filter(_.uid.isDefined).map(_.uid.get)
+    val user_sid: Option[Int] = optionalInfo.filter(_.userSid.isDefined).map(_.userSid.get)
+    val visible: Option[Boolean] = optionalInfo.filter(_.visible.isDefined).map(_.visible.get)
+
+    WayEntity(
+      id = osmosisWay.id,
+      nodes = nodes,
+      tags = tags,
+      version = version,
+      timestamp = timestamp,
+      changeset = changeset,
+      uid = uid,
+      user_sid = user_sid,
+      visible = visible
+    )
   }
 
 }

--- a/core/src/main/scala/com/acervera/osm4scala/model/WayEntity.scala
+++ b/core/src/main/scala/com/acervera/osm4scala/model/WayEntity.scala
@@ -25,6 +25,7 @@
 
 package com.acervera.osm4scala.model
 
+import com.acervera.osm4scala.utilities.DecompressUtils
 import org.openstreetmap.osmosis.osmbinary.osmformat.{Info, StringTable, Way}
 
 /**
@@ -37,7 +38,7 @@ case class WayEntity(id: Long,
                      timestamp: Option[Long],
                      changeset: Option[Long],
                      uid: Option[Int],
-                     user_sid: Option[Int],
+                     user: Option[String],
                      visible: Option[Boolean]) extends OSMEntity {
 
   override val osmModel: OSMTypes.Value = OSMTypes.Way
@@ -57,7 +58,7 @@ case class WayEntity(id: Long,
       s"timestamp: ${timestamp.getOrElse("None")}, " +
       s"changeset: ${changeset.getOrElse("None")}, " +
       s"uid: ${uid.getOrElse("None")}, " +
-      s"user_sid: ${user_sid.getOrElse("None")}, " +
+      s"user: ${user.getOrElse("None")}, " +
       s"visible: ${visible.getOrElse("True")}\n"
   }
 
@@ -88,14 +89,15 @@ object WayEntity {
 
     // Calculate tags using the StringTable.
     val tags = (osmosisWay.keys, osmosisWay.vals).zipped.map { (k, v) =>
-      osmosisStringTable.s(k).toString("UTF-8") -> osmosisStringTable.s(v).toString("UTF-8")
+      osmosisStringTable.s(k).toString(DecompressUtils.STRING_ENCODER) -> osmosisStringTable.s(v).toString(DecompressUtils.STRING_ENCODER)
     }.toMap
 
     val version: Option[Int] = optionalInfo.filter(_.version.isDefined).map(_.version.get)
-    val timestamp: Option[Long] = optionalInfo.filter(_.timestamp.isDefined).map(_.version.get * _dateGranularity)
+    val timestamp: Option[Long] = optionalInfo.filter(_.timestamp.isDefined).map(_.timestamp.get * _dateGranularity)
     val changeset: Option[Long] = optionalInfo.filter(_.changeset.isDefined).map(_.changeset.get)
     val uid: Option[Int] = optionalInfo.filter(_.uid.isDefined).map(_.uid.get)
-    val user_sid: Option[Int] = optionalInfo.filter(_.userSid.isDefined).map(_.userSid.get)
+    val userSid: Option[Int] = optionalInfo.filter(_.userSid.isDefined).map(_.userSid.get)
+    val user: Option[String] = userSid.map(usersid => osmosisStringTable.s(usersid).toString(DecompressUtils.STRING_ENCODER))
     val visible: Option[Boolean] = optionalInfo.filter(_.visible.isDefined).map(_.visible.get)
 
     WayEntity(
@@ -106,7 +108,7 @@ object WayEntity {
       timestamp = timestamp,
       changeset = changeset,
       uid = uid,
-      user_sid = user_sid,
+      user = user,
       visible = visible
     )
   }

--- a/core/src/main/scala/com/acervera/osm4scala/utilities/DecompressUtils.scala
+++ b/core/src/main/scala/com/acervera/osm4scala/utilities/DecompressUtils.scala
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.acervera.osm4scala.utilities
+
+/**
+  * This Util object store the way to decompress osm entity fields. Based on wiki
+  * here: https://wiki.openstreetmap.org/wiki/PBF_Format#File_format
+  * We need to decompress coordinates, timestamp, changeset, uid and user_sid when
+  * processing DenseNode and Dense Info
+  */
+object DecompressUtils {
+
+  def iteratorCheck[A](iterator: Iterator[A]): Option[A] = {
+    if(iterator.isEmpty || !iterator.hasNext) None else Option[A](iterator.next())
+  }
+  /**
+    * Calculate coordinate applying offset, granularity and delta.
+    *
+    * @param offSet
+    * @param delta
+    * @param currentValue
+    * @return
+    */
+  def decompressCoord(offSet: Long,
+                      delta: Long,
+                      granularity: Long,
+                      currentValue: Double): Double = {
+    (.000000001 * (offSet + (granularity * delta))) + currentValue
+  }
+
+  def decompressTimestamp(currentTimeStampOffSet: Option[Long],
+                          dateGranularity: Int,
+                          lastTimestamp: Option[Long]): Option[Long] = {
+    currentTimeStampOffSet.map(
+      offSet => offSet*dateGranularity + lastTimestamp.getOrElse(0L)
+    )
+  }
+
+  def decompressChangeset(currentChangsetOffSet: Option[Long],
+                          lastChangset: Option[Long]): Option[Long] = {
+    currentChangsetOffSet.map(offSet => offSet + lastChangset.getOrElse(0L))
+  }
+
+  def decompressUid(currentUidOffSet: Option[Int],
+                    lastUid: Option[Int]): Option[Int] = {
+    currentUidOffSet.map(offSet => offSet + lastUid.getOrElse(0))
+  }
+
+  def decompressUserSid(currentUserUidOffSet: Option[Int],
+                       lastUserSid: Option[Int]): Option[Int] = {
+    currentUserUidOffSet.map(offSet => offSet + lastUserSid.getOrElse(0))
+  }
+}

--- a/core/src/main/scala/com/acervera/osm4scala/utilities/DecompressUtils.scala
+++ b/core/src/main/scala/com/acervera/osm4scala/utilities/DecompressUtils.scala
@@ -33,6 +33,9 @@ package com.acervera.osm4scala.utilities
   */
 object DecompressUtils {
 
+  private val COORDINATE_SCALING_FACTOR = 0.000000001
+  val STRING_ENCODER: String = "UTF-8"
+
   def iteratorCheck[A](iterator: Iterator[A]): Option[A] = {
     if(iterator.isEmpty || !iterator.hasNext) None else Option[A](iterator.next())
   }
@@ -48,7 +51,7 @@ object DecompressUtils {
                       delta: Long,
                       granularity: Long,
                       currentValue: Double): Double = {
-    (.000000001 * (offSet + (granularity * delta))) + currentValue
+    (this.COORDINATE_SCALING_FACTOR * (offSet + (granularity * delta))) + currentValue
   }
 
   def decompressTimestamp(currentTimeStampOffSet: Option[Long],

--- a/core/src/test/scala/com/acervera/osm4scala/FromPbfFileEntitiesIteratorSpec.scala
+++ b/core/src/test/scala/com/acervera/osm4scala/FromPbfFileEntitiesIteratorSpec.scala
@@ -25,7 +25,7 @@
 
 package com.acervera.osm4scala
 
-import java.io.{FileInputStream, InputStream}
+import java.io.{FileInputStream, FileOutputStream, InputStream, ObjectOutputStream}
 
 import com.acervera.osm4scala.EntityIterator._
 import com.acervera.osm4scala.model.{NodeEntity, RelationEntity, WayEntity}
@@ -65,6 +65,24 @@ class FromPbfFileEntitiesIteratorSpec extends AnyWordSpec with Matchers {
       assert(relationsCounter == 10357, "There are 10.357 relations in Madrid!")
       assert(othersCounter == 0, "No different type of entities!")
 
+    }
+
+    "Read Entities correctly" in {
+      val testFile = "core/src/test/resources/com/acervera/osm4scala/delaware-latest.osm.pbf"
+      var pbfIS: InputStream = null
+      try {
+        pbfIS = new FileInputStream(testFile)
+        val readFile: EntityIterator = fromPbf(pbfIS)
+        val out = new ObjectOutputStream(new FileOutputStream("core/src/test/resources/com/acervera/osm4scala/delaware-latest.txt"))
+        readFile.foreach(x =>
+          out.writeObject(x.toString)
+        )
+        out.close()
+
+
+      } finally {
+        if (pbfIS != null) pbfIS.close()
+      }
     }
   }
 

--- a/core/src/test/scala/com/acervera/osm4scala/FromPbfFileEntitiesIteratorSpec.scala
+++ b/core/src/test/scala/com/acervera/osm4scala/FromPbfFileEntitiesIteratorSpec.scala
@@ -70,18 +70,21 @@ class FromPbfFileEntitiesIteratorSpec extends AnyWordSpec with Matchers {
     "Read Entities correctly" in {
       val testFile = "core/src/test/resources/com/acervera/osm4scala/delaware-latest.osm.pbf"
       var pbfIS: InputStream = null
-      try {
-        pbfIS = new FileInputStream(testFile)
-        val readFile: EntityIterator = fromPbf(pbfIS)
-        val out = new ObjectOutputStream(new FileOutputStream("core/src/test/resources/com/acervera/osm4scala/delaware-latest.txt"))
-        readFile.foreach(x =>
-          out.writeObject(x.toString)
-        )
-        out.close()
+      val write = false
+      if(write) {
+        try {
+          pbfIS = new FileInputStream(testFile)
+          val readFile: EntityIterator = fromPbf(pbfIS)
+          val out = new ObjectOutputStream(new FileOutputStream("core/src/test/resources/com/acervera/osm4scala/delaware-latest.txt"))
+          readFile.foreach(x =>
+            out.writeObject(x.toString)
+          )
+          out.close()
 
 
-      } finally {
-        if (pbfIS != null) pbfIS.close()
+        } finally {
+          if (pbfIS != null) pbfIS.close()
+        }
       }
     }
   }

--- a/core/src/test/scala/com/acervera/osm4scala/model/RelationEntitySuite.scala
+++ b/core/src/test/scala/com/acervera/osm4scala/model/RelationEntitySuite.scala
@@ -42,8 +42,7 @@ class RelationEntitySuite extends AnyFunSuite {
     val osmosisRelation = Relation parseFrom new FileInputStream("core/src/test/resources/com/acervera/osm4scala/osmblock/relations/8486/7954.relation")
 
     // Test
-    val relation = RelationEntity(strTable, osmosisRelation)
-
+    val relation = RelationEntity(osmosisStringTable = strTable, osmosisRelation = osmosisRelation)
     assert(relation.id === 2898444)
     assert(relation.relations === List(RelationMemberEntity(219042667,RelationMemberEntityTypes.Way,"inner"),RelationMemberEntity(219042634,RelationMemberEntityTypes.Way,"outer")))
     assert(relation.tags == Map("type" -> "multipolygon"))

--- a/core/src/test/scala/com/acervera/osm4scala/model/WayEntitySuite.scala
+++ b/core/src/test/scala/com/acervera/osm4scala/model/WayEntitySuite.scala
@@ -43,7 +43,7 @@ class WayEntitySuite extends AnyFunSuite {
     val osmosisWay = Way parseFrom new FileInputStream("core/src/test/resources/com/acervera/osm4scala/osmblock/ways/8133/280.way")
 
     // Test
-    val way = WayEntity(strTable, osmosisWay)
+    val way = WayEntity(osmosisStringTable = strTable, osmosisWay = osmosisWay)
     assert(way.id === 199785422)
     assert(way.nodes === List(2097786485L, 2097786450L, 2097786416L, 2097786358L))
     assert(way.tags == Map("source" -> "PNOA", "highway" -> "path", "surface" -> "ground"))

--- a/spark/src/main/scala/com/acervera/osm4scala/spark/OsmPbfRowIterator.scala
+++ b/spark/src/main/scala/com/acervera/osm4scala/spark/OsmPbfRowIterator.scala
@@ -91,6 +91,12 @@ object OsmPbfRowIterator {
       case OsmSqlEntity.FIELD_NODES     => UnsafeArrayData.fromPrimitiveArray(Array.empty[Long])
       case OsmSqlEntity.FIELD_RELATIONS => new GenericArrayData(Seq.empty)
       case FIELD_TAGS                   => calculateTags(entity.tags)
+      case FIELD_VERSION                => entity.version.getOrElse[Int](-1)
+      case FIELD_TIMESTAMP              => entity.timestamp.getOrElse[Long](-1)
+      case FIELD_CHANGESET              => entity.changeset.getOrElse[Long](-1)
+      case FIELD_UID                    => entity.uid.getOrElse[Int](-1)
+      case FIELD_USER_SID               => entity.user_sid.getOrElse[Int](-1)
+      case FIELD_VISIBLE                => entity.visible.getOrElse[Boolean](true)
     }
 
     private def populateWay(entity: WayEntity, structType: StructType): Seq[Any] = structType.fieldNames.map {
@@ -101,6 +107,12 @@ object OsmPbfRowIterator {
       case OsmSqlEntity.FIELD_NODES     => UnsafeArrayData.fromPrimitiveArray(entity.nodes.toArray)
       case OsmSqlEntity.FIELD_RELATIONS => new GenericArrayData(Seq.empty)
       case FIELD_TAGS                   => calculateTags(entity.tags)
+      case FIELD_VERSION                => entity.version.getOrElse[Int](-1)
+      case FIELD_TIMESTAMP              => entity.timestamp.getOrElse[Long](-1)
+      case FIELD_CHANGESET              => entity.changeset.getOrElse[Long](-1)
+      case FIELD_UID                    => entity.uid.getOrElse[Int](-1)
+      case FIELD_USER_SID               => entity.user_sid.getOrElse[Int](-1)
+      case FIELD_VISIBLE                => entity.visible.getOrElse[Boolean](true)
     }
 
     private def populateRelation(entity: RelationEntity, structType: StructType): Seq[Any] =
@@ -113,6 +125,12 @@ object OsmPbfRowIterator {
           case OsmSqlEntity.FIELD_NODES     => UnsafeArrayData.fromPrimitiveArray(Seq.empty[Long].toArray)
           case OsmSqlEntity.FIELD_RELATIONS => calculateRelations(entity.relations, f)
           case FIELD_TAGS                   => calculateTags(entity.tags)
+          case FIELD_VERSION                => entity.version.getOrElse[Int](-1)
+          case FIELD_TIMESTAMP              => entity.timestamp.getOrElse[Long](-1)
+          case FIELD_CHANGESET              => entity.changeset.getOrElse[Long](-1)
+          case FIELD_UID                    => entity.uid.getOrElse[Int](-1)
+          case FIELD_USER_SID               => entity.user_sid.getOrElse[Int](-1)
+          case FIELD_VISIBLE                => entity.visible.getOrElse[Boolean](true)
       })
 
     def toSQLTypesSeq(structType: StructType): Seq[Any] = osmEntity match {

--- a/spark/src/main/scala/com/acervera/osm4scala/spark/OsmPbfRowIterator.scala
+++ b/spark/src/main/scala/com/acervera/osm4scala/spark/OsmPbfRowIterator.scala
@@ -91,11 +91,11 @@ object OsmPbfRowIterator {
       case OsmSqlEntity.FIELD_NODES     => UnsafeArrayData.fromPrimitiveArray(Array.empty[Long])
       case OsmSqlEntity.FIELD_RELATIONS => new GenericArrayData(Seq.empty)
       case FIELD_TAGS                   => calculateTags(entity.tags)
-      case FIELD_VERSION                => entity.version.getOrElse[Int](-1)
-      case FIELD_TIMESTAMP              => entity.timestamp.getOrElse[Long](-1)
-      case FIELD_CHANGESET              => entity.changeset.getOrElse[Long](-1)
-      case FIELD_UID                    => entity.uid.getOrElse[Int](-1)
-      case FIELD_USER_SID               => entity.user_sid.getOrElse[Int](-1)
+      case FIELD_VERSION                => if(entity.version.isDefined) entity.version.get else null
+      case FIELD_TIMESTAMP              => if(entity.timestamp.isDefined) entity.timestamp.get else null
+      case FIELD_CHANGESET              => if(entity.changeset.isDefined) entity.changeset.get else null
+      case FIELD_UID                    => if(entity.uid.isDefined) entity.uid.get else null
+      case FIELD_USER                   => if (entity.user.isDefined) UTF8String.fromString(entity.user.get) else null
       case FIELD_VISIBLE                => entity.visible.getOrElse[Boolean](true)
     }
 
@@ -107,11 +107,11 @@ object OsmPbfRowIterator {
       case OsmSqlEntity.FIELD_NODES     => UnsafeArrayData.fromPrimitiveArray(entity.nodes.toArray)
       case OsmSqlEntity.FIELD_RELATIONS => new GenericArrayData(Seq.empty)
       case FIELD_TAGS                   => calculateTags(entity.tags)
-      case FIELD_VERSION                => entity.version.getOrElse[Int](-1)
-      case FIELD_TIMESTAMP              => entity.timestamp.getOrElse[Long](-1)
-      case FIELD_CHANGESET              => entity.changeset.getOrElse[Long](-1)
-      case FIELD_UID                    => entity.uid.getOrElse[Int](-1)
-      case FIELD_USER_SID               => entity.user_sid.getOrElse[Int](-1)
+      case FIELD_VERSION                => if(entity.version.isDefined) entity.version.get else null
+      case FIELD_TIMESTAMP              => if(entity.timestamp.isDefined) entity.timestamp.get else null
+      case FIELD_CHANGESET              => if(entity.changeset.isDefined) entity.changeset.get else null
+      case FIELD_UID                    => if(entity.uid.isDefined) entity.uid.get else null
+      case FIELD_USER                   => if(entity.user.isDefined) UTF8String.fromString(entity.user.get) else null
       case FIELD_VISIBLE                => entity.visible.getOrElse[Boolean](true)
     }
 
@@ -125,11 +125,11 @@ object OsmPbfRowIterator {
           case OsmSqlEntity.FIELD_NODES     => UnsafeArrayData.fromPrimitiveArray(Seq.empty[Long].toArray)
           case OsmSqlEntity.FIELD_RELATIONS => calculateRelations(entity.relations, f)
           case FIELD_TAGS                   => calculateTags(entity.tags)
-          case FIELD_VERSION                => entity.version.getOrElse[Int](-1)
-          case FIELD_TIMESTAMP              => entity.timestamp.getOrElse[Long](-1)
-          case FIELD_CHANGESET              => entity.changeset.getOrElse[Long](-1)
-          case FIELD_UID                    => entity.uid.getOrElse[Int](-1)
-          case FIELD_USER_SID               => entity.user_sid.getOrElse[Int](-1)
+          case FIELD_VERSION                => if(entity.version.isDefined) entity.version.get else null
+          case FIELD_TIMESTAMP              => if(entity.timestamp.isDefined) entity.timestamp.get else null
+          case FIELD_CHANGESET              => if(entity.changeset.isDefined) entity.changeset.get else null
+          case FIELD_UID                    => if(entity.uid.isDefined) entity.uid.get else null
+          case FIELD_USER                   => if(entity.user.isDefined) UTF8String.fromString(entity.user.get) else null
           case FIELD_VISIBLE                => entity.visible.getOrElse[Boolean](true)
       })
 

--- a/spark/src/main/scala/com/acervera/osm4scala/spark/OsmSqlEntity.scala
+++ b/spark/src/main/scala/com/acervera/osm4scala/spark/OsmSqlEntity.scala
@@ -40,6 +40,13 @@ object OsmSqlEntity {
   val FIELD_RELATIONS_ID = "id"
   val FIELD_RELATIONS_TYPE = "relationType"
   val FIELD_RELATIONS_ROLE = "role"
+  //Common Option Field
+  val FIELD_VERSION = "version"
+  val FIELD_TIMESTAMP = "timestamp"
+  val FIELD_CHANGESET = "changeset"
+  val FIELD_UID = "uid"
+  val FIELD_USER_SID = "user_sid"
+  val FIELD_VISIBLE = "visible"
 
   val ENTITY_TYPE_NODE: Byte = 0
   val ENTITY_TYPE_WAY: Byte = 1
@@ -57,13 +64,15 @@ object OsmSqlEntity {
     case RelationMemberEntityTypes.Unrecognized => RELATION_UNRECOGNIZED
   }
 
-  lazy val relationSchema = StructType(
-    Seq(StructField(FIELD_RELATIONS_ID, LongType, false),
-        StructField(FIELD_RELATIONS_TYPE, ByteType, false),
-        StructField(FIELD_RELATIONS_ROLE, StringType, true))
+  lazy val relationSchema: StructType = StructType(
+    Seq(
+      StructField(FIELD_RELATIONS_ID, LongType, false),
+      StructField(FIELD_RELATIONS_TYPE, ByteType, false),
+      StructField(FIELD_RELATIONS_ROLE, StringType, true)
+    )
   )
 
-  lazy val schema = StructType(
+  lazy val schema: StructType = StructType(
     Seq(
       StructField(FIELD_ID, LongType, false),
       StructField(FIELD_TYPE, ByteType, false),
@@ -71,7 +80,13 @@ object OsmSqlEntity {
       StructField(FIELD_LONGITUDE, DoubleType, true),
       StructField(FIELD_NODES, ArrayType(LongType, false), true),
       StructField(FIELD_RELATIONS, ArrayType(relationSchema, false), true),
-      StructField(FIELD_TAGS, MapType(StringType, StringType, false), true)
+      StructField(FIELD_TAGS, MapType(StringType, StringType, false), true),
+      StructField(FIELD_VERSION, IntegerType, true),
+      StructField(FIELD_TIMESTAMP, LongType, true),
+      StructField(FIELD_CHANGESET, LongType, true),
+      StructField(FIELD_UID, IntegerType, true),
+      StructField(FIELD_USER_SID, IntegerType, true),
+      StructField(FIELD_VISIBLE, BooleanType, true)
     ))
 
 }

--- a/spark/src/main/scala/com/acervera/osm4scala/spark/OsmSqlEntity.scala
+++ b/spark/src/main/scala/com/acervera/osm4scala/spark/OsmSqlEntity.scala
@@ -45,7 +45,7 @@ object OsmSqlEntity {
   val FIELD_TIMESTAMP = "timestamp"
   val FIELD_CHANGESET = "changeset"
   val FIELD_UID = "uid"
-  val FIELD_USER_SID = "user_sid"
+  val FIELD_USER = "user"
   val FIELD_VISIBLE = "visible"
 
   val ENTITY_TYPE_NODE: Byte = 0
@@ -85,7 +85,7 @@ object OsmSqlEntity {
       StructField(FIELD_TIMESTAMP, LongType, true),
       StructField(FIELD_CHANGESET, LongType, true),
       StructField(FIELD_UID, IntegerType, true),
-      StructField(FIELD_USER_SID, IntegerType, true),
+      StructField(FIELD_USER, StringType, true),
       StructField(FIELD_VISIBLE, BooleanType, true)
     ))
 


### PR DESCRIPTION

Fixes #40
Expose all optional info fields listed here to PBFIterator and SparkConnector: 
```
message Info {
   optional int32 version = 1 [default = -1];
   optional int32 timestamp = 2;
   optional int64 changeset = 3;
   optional int32 uid = 4;
   optional int32 user_sid = 5; // String IDs
   optional bool visible = 6;
}
```
Will add more integration test when exporting PBF/XML is available. Create a ticket for adding bbox info if needed in future.

Reference: 
1. https://wiki.openstreetmap.org/wiki/PBF_Format
2. https://github.com/openstreetmap/osmosis/blob/2219470cef1f73f5d1319c57149c84b398e767ce/osmosis-pbf2/src/main/java/org/openstreetmap/osmosis/pbf2/v0_6/impl/PbfFieldDecoder.java
3. https://github.com/openstreetmap/osmosis/blob/2219470cef1f73f5d1319c57149c84b398e767ce/osmosis-pbf2/src/main/java/org/openstreetmap/osmosis/pbf2/v0_6/impl/PbfBlobDecoder.java